### PR TITLE
Clean up yml file and remove build output option

### DIFF
--- a/.github/workflows/PublishToAzure.yml
+++ b/.github/workflows/PublishToAzure.yml
@@ -1,45 +1,21 @@
-# This workflow will build a .NET Core project and deploy it to an Azure Functions App on Windows or Linux when a commit is pushed to your default branch.
-#
-# This workflow assumes you have already created the target Azure Functions app.
-# For instructions see https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-vs-code-csharp?tabs=in-process
-#
-# To configure this workflow:
-# 1. Set up the following secrets in your repository:
-#   - AZURE_FUNCTIONAPP_PUBLISH_PROFILE
-# 2. Change env variables for your configuration.
-#
-# For more information on:
-#   - GitHub Actions for Azure: https://github.com/Azure/Actions
-#   - Azure Functions Action: https://github.com/Azure/functions-action
-#   - Publish Profile: https://github.com/Azure/functions-action#using-publish-profile-as-deployment-credential-recommended
-#   - Azure Service Principal for RBAC: https://github.com/Azure/functions-action#using-azure-service-principal-for-rbac-as-deployment-credential
-#
-# For more samples to get started with GitHub Action workflows to deploy to Azure: https://github.com/Azure/actions-workflow-samples/tree/master/FunctionApp
-
-name: Deploy DotNet project to Azure Function App
+name: PublishToAzure
 
 on:
   push:
     branches: ["main"]
 
 env:
-  AZURE_FUNCTIONAPP_NAME: 'WebhooksTriggerApp'   # set this to your function app name on Azure
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'       # set this to the path to your function app project, defaults to the repository root
-  DOTNET_VERSION: '8.0.x'                   # set this to the dotnet version to use (e.g. '2.1.x', '3.1.x', '5.0.x')
+  AZURE_FUNCTIONAPP_NAME: 'WebhooksTriggerApp'
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'
+  DOTNET_VERSION: '8.0.x'
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest # For Linux, use ubuntu-latest
+    runs-on: windows-latest
     environment: dev
     steps:
     - name: 'Checkout GitHub Action'
       uses: actions/checkout@v4
-
-    # If you want to use Azure RBAC instead of Publish Profile, then uncomment the task below
-    # - name: 'Login via Azure CLI'
-    #   uses: azure/login@v1
-    #   with:
-    #     creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }} # set up AZURE_RBAC_CREDENTIALS secrets in your repository
 
     - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
       uses: actions/setup-dotnet@v4
@@ -47,10 +23,10 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: 'Resolve Project Dependencies Using Dotnet'
-      shell: pwsh # For Linux, use bash
+      shell: pwsh
       run: |
         pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
-        dotnet build --configuration Release --output ./output
+        dotnet build --configuration Release
         popd
 
     - name: 'Run Azure Functions Action'
@@ -59,4 +35,4 @@ jobs:
       with:
         app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
         package: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output'
-        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }} # Remove publish-profile to use Azure RBAC
+        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}


### PR DESCRIPTION
This pull request includes changes to streamline and simplify the `.github/workflows/PublishToAzure.yml` workflow file for deploying a .NET project to Azure Functions. The most important changes include renaming the workflow, removing comments and unnecessary lines, and updating environment variables.

Streamlining the workflow:

* [`.github/workflows/PublishToAzure.yml`](diffhunk://#diff-4866a9d1fd8209f34bcd39235a11d941751c525e90a8b15a4504e01b107a959bL1-R29): Renamed the workflow from "Deploy DotNet project to Azure Function App" to "PublishToAzure".
* [`.github/workflows/PublishToAzure.yml`](diffhunk://#diff-4866a9d1fd8209f34bcd39235a11d941751c525e90a8b15a4504e01b107a959bL1-R29): Removed extensive comments and instructions to simplify the file.

Simplifying the configuration:

* [`.github/workflows/PublishToAzure.yml`](diffhunk://#diff-4866a9d1fd8209f34bcd39235a11d941751c525e90a8b15a4504e01b107a959bL1-R29): Consolidated environment variable definitions by removing redundant comments.
* [`.github/workflows/PublishToAzure.yml`](diffhunk://#diff-4866a9d1fd8209f34bcd39235a11d941751c525e90a8b15a4504e01b107a959bL1-R29): Removed the option to use Azure RBAC, leaving only the publish profile method for deployment. [[1]](diffhunk://#diff-4866a9d1fd8209f34bcd39235a11d941751c525e90a8b15a4504e01b107a959bL1-R29) [[2]](diffhunk://#diff-4866a9d1fd8209f34bcd39235a11d941751c525e90a8b15a4504e01b107a959bL62-R38)
* [`.github/workflows/PublishToAzure.yml`](diffhunk://#diff-4866a9d1fd8209f34bcd39235a11d941751c525e90a8b15a4504e01b107a959bL1-R29): Simplified the `dotnet build` command by removing the output directory specification.